### PR TITLE
Add copyright and license headers to code files

### DIFF
--- a/.github/workflows/headers.yml
+++ b/.github/workflows/headers.yml
@@ -1,0 +1,13 @@
+name: headers
+run-name: License headers check by ${{ github.actor }}
+
+on: [push, pull_request]
+
+jobs:
+  header-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Check License Header
+        uses: apache/skywalking-eyes/header@main

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,13 @@
+header:
+  license:
+    content: |
+      Copyright (c) Meta Platforms, Inc. and affiliates.
+
+      This source code is licensed under the MIT license found in the
+      LICENSE file in the root directory of this source tree.
+
+  paths:
+    - "**/*.py"
+    - "**/*.sh"
+
+  comment: never

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ The library needed to run our code is
 Please read CONTRIBUTING.md for details on our code of conduct, and the process for submitting pull requests.
 
 ## License
-This project is licensed under the MIT License - see the LICENSE.md file for details. The license applies to the released data as well.
+This project is licensed under the MIT License - see the `LICENSE` file for details. The license applies to the released data as well.
 
 ## Contact
-RAM is currently maintained by Olga Golovneva, Ilia Kulikov, Xian Li, Richard Pang, Sainbayar Sukhbaatar, Tianlu Wang, Jason Weston, Jing Xu, Jane Dwivedi-Yu, Ping Yu, Weizhe Yuan.
+RAM is currently maintained by Olga Golovneva, Ilia Kulikov, Janice Lan, Xian Li, Richard Pang, Sainbayar Sukhbaatar, Tianlu Wang, Jason Weston, Jing Xu, Jane Dwivedi-Yu, Ping Yu, Weizhe Yuan.
 For any queries, please reach out to [Jing Xu](https://github.com/jxmsML).

--- a/projects/cope/eval.py
+++ b/projects/cope/eval.py
@@ -1,3 +1,10 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
 from argparse import ArgumentParser
 
 import torch

--- a/projects/cope/run.sh
+++ b/projects/cope/run.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
 # Example set of commands that generates data, trains, and evaluates.
 
 function gen_data {

--- a/projects/cope/scripts/count_data_gen.py
+++ b/projects/cope/scripts/count_data_gen.py
@@ -1,3 +1,10 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
 import argparse
 import json
 import os

--- a/projects/cope/src/cope/context_position.py
+++ b/projects/cope/src/cope/context_position.py
@@ -1,3 +1,10 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
 import math
 from argparse import ArgumentParser, BooleanOptionalAction
 from typing import Optional

--- a/projects/cope/src/data/__init__.py
+++ b/projects/cope/src/data/__init__.py
@@ -1,3 +1,10 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
 import argparse
 import logging
 

--- a/projects/cope/src/data/constants.py
+++ b/projects/cope/src/data/constants.py
@@ -1,3 +1,10 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
 CONTEXT_KEY = "context"
 QUESTION_KEY = "question"
 ANSWER_KEY = "answer"

--- a/projects/cope/src/data/data_collator.py
+++ b/projects/cope/src/data/data_collator.py
@@ -1,3 +1,10 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
 import torch
 
 from .constants import (

--- a/projects/cope/src/data/simple.py
+++ b/projects/cope/src/data/simple.py
@@ -1,3 +1,10 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
 import json
 import os
 

--- a/projects/cope/src/data/tokenizer.py
+++ b/projects/cope/src/data/tokenizer.py
@@ -1,3 +1,10 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
 from abc import ABC, abstractmethod
 
 from .constants import ANSWER_KEY, CONTEXT_KEY, QUESTION_KEY

--- a/projects/cope/src/main.py
+++ b/projects/cope/src/main.py
@@ -1,3 +1,10 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
 import logging
 import os
 import random

--- a/projects/cope/src/models/__init__.py
+++ b/projects/cope/src/models/__init__.py
@@ -1,3 +1,10 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
 from argparse import ArgumentParser, BooleanOptionalAction, Namespace
 
 import torch

--- a/projects/cope/src/models/base.py
+++ b/projects/cope/src/models/base.py
@@ -1,3 +1,10 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
 from abc import ABC, abstractmethod
 from typing import List, Optional
 

--- a/projects/cope/src/models/relative_position.py
+++ b/projects/cope/src/models/relative_position.py
@@ -1,3 +1,10 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
 from typing import Optional
 
 import torch

--- a/projects/cope/src/models/simple_transformer.py
+++ b/projects/cope/src/models/simple_transformer.py
@@ -1,3 +1,10 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
 from argparse import ArgumentParser, BooleanOptionalAction
 from typing import List, Optional
 

--- a/projects/cope/src/models/transformer.py
+++ b/projects/cope/src/models/transformer.py
@@ -1,3 +1,10 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
 import math
 from typing import Optional
 

--- a/projects/cope/src/trainer.py
+++ b/projects/cope/src/trainer.py
@@ -1,3 +1,10 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
 import logging
 import time
 from argparse import ArgumentParser, BooleanOptionalAction, Namespace

--- a/projects/cope/src/utils/__init__.py
+++ b/projects/cope/src/utils/__init__.py
@@ -1,3 +1,10 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 

--- a/projects/cope/src/utils/checkpoint.py
+++ b/projects/cope/src/utils/checkpoint.py
@@ -1,4 +1,9 @@
-"""Checkpointing utils"""
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
 
 import logging
 import os
@@ -7,6 +12,8 @@ from argparse import ArgumentParser, BooleanOptionalAction
 import torch
 from torch import distributed
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+
+"""Checkpointing utils"""
 
 
 def add_args(parser: ArgumentParser):

--- a/projects/cope/src/utils/distributed.py
+++ b/projects/cope/src/utils/distributed.py
@@ -1,3 +1,10 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
 import contextlib
 import functools
 import os

--- a/projects/cope/src/utils/logger.py
+++ b/projects/cope/src/utils/logger.py
@@ -1,3 +1,10 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
 import math
 import os
 from argparse import ArgumentParser, BooleanOptionalAction

--- a/projects/cope/src/utils/world.py
+++ b/projects/cope/src/utils/world.py
@@ -1,3 +1,10 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
 from abc import ABC, abstractmethod
 from argparse import ArgumentParser, BooleanOptionalAction
 from typing import Optional

--- a/projects/cope/train.py
+++ b/projects/cope/train.py
@@ -1,3 +1,10 @@
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
 from argparse import ArgumentParser
 
 from src.main import add_train_args, train

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates
-# All rights reserved.
-#
-# This source code is licensed under the license found in the
-# LICENSE file in the root directory of this source tree.
+"""
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
 
 from setuptools import find_packages, setup
 


### PR DESCRIPTION
Add copyright and license headers to code files added in CoPE release. Also add github actions to check for the header in files added in the future.